### PR TITLE
Session/3

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -10,6 +10,7 @@
     "editor.defaultFormatter": "esbenp.prettier-vscode"
   },
   "cSpell.words": [
+    "unawaited",
     "Yumemi"
   ]
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_training/main_page_layout.dart';
+import 'package:flutter_training/start_screen.dart';
 
 void main() {
   runApp(const MainApp());
@@ -12,7 +12,7 @@ class MainApp extends StatelessWidget {
   Widget build(BuildContext context) {
     return const MaterialApp(
       title: 'Weather App',
-      home: MainPageLayout(),
+      home: StartScreen(),
     );
   }
 }

--- a/lib/main_page_layout.dart
+++ b/lib/main_page_layout.dart
@@ -18,7 +18,9 @@ class MainPageLayoutState extends State<MainPageLayout> {
 
   void _updateWeatherCondition(WeatherCondition newWeatherCondition) {
     setState(() {
-      _weatherCondition = newWeatherCondition;
+      if (mounted) {
+        _weatherCondition = newWeatherCondition;
+      }
     });
   }
 
@@ -135,7 +137,9 @@ class _TextButtons extends StatelessWidget {
       children: <Widget>[
         Expanded(
           child: TextButton(
-            onPressed: () {},
+            onPressed: () {
+              Navigator.of(context).pop();
+            },
             child: const Text('Close'),
           ),
         ),

--- a/lib/main_page_layout.dart
+++ b/lib/main_page_layout.dart
@@ -138,6 +138,7 @@ class _TextButtons extends StatelessWidget {
         Expanded(
           child: TextButton(
             onPressed: () {
+              // 遷移元へ戻す
               Navigator.of(context).pop();
             },
             child: const Text('Close'),

--- a/lib/start_screen.dart
+++ b/lib/start_screen.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_training/main_page_layout.dart';
 
@@ -10,17 +12,27 @@ class StartScreen extends StatefulWidget {
 }
 
 class _StartScreenState extends State<StartScreen> {
+  /// 開始から0.5秒遅らせて、メイン画面に遷移
+  Future<void> _navigateMainPage() async {
+    await Future<void>.delayed(const Duration(milliseconds: 500));
+    if (mounted) {
+      final route = MaterialPageRoute<void>(
+        builder: (context) => const MainPageLayout(),
+      );
+      final navigatorState = Navigator.of(context);
+      await navigatorState.push(route);
+      unawaited(_navigateMainPage());
+    }
+  }
+
   @override
   void initState() {
     super.initState();
-    final navigatorState = Navigator.of(context);
-    final route = MaterialPageRoute<void>(
-      builder: (context) => const MainPageLayout(),
+    unawaited(
+      WidgetsBinding.instance.endOfFrame.then((_) {
+        _navigateMainPage();
+      }),
     );
-    // 開始から5秒遅らせて、メイン画面に遷移
-    Future.delayed(const Duration(milliseconds: 500), () async {
-      await navigatorState.push(route);
-    });
   }
 
   @override

--- a/lib/start_screen.dart
+++ b/lib/start_screen.dart
@@ -1,0 +1,20 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_training/main_page_layout.dart';
+
+class StartScreen extends StatelessWidget {
+  const StartScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return ElevatedButton(
+      child: const Text('メイン画面へ'),
+      onPressed: () async {
+        final navigatorState = Navigator.of(context);
+        final route = MaterialPageRoute<void>(
+          builder: (context) => const MainPageLayout(),
+        );
+        await navigatorState.push(route);
+      },
+    );
+  }
+}

--- a/lib/start_screen.dart
+++ b/lib/start_screen.dart
@@ -1,20 +1,28 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_training/main_page_layout.dart';
 
-class StartScreen extends StatelessWidget {
+class StartScreen extends StatefulWidget {
   const StartScreen({super.key});
 
   @override
+  State<StartScreen> createState() => StartScreenState();
+}
+
+class StartScreenState extends State<StartScreen> {
+  @override
   Widget build(BuildContext context) {
-    return ElevatedButton(
-      child: const Text('メイン画面へ'),
-      onPressed: () async {
-        final navigatorState = Navigator.of(context);
-        final route = MaterialPageRoute<void>(
-          builder: (context) => const MainPageLayout(),
-        );
-        await navigatorState.push(route);
-      },
+    return ColoredBox(
+      color: Colors.green,
+      child: TextButton(
+        child: const Text('メイン画面へ'),
+        onPressed: () async {
+          final navigatorState = Navigator.of(context);
+          final route = MaterialPageRoute<void>(
+            builder: (context) => const MainPageLayout(),
+          );
+          await navigatorState.push(route);
+        },
+      ),
     );
   }
 }

--- a/lib/start_screen.dart
+++ b/lib/start_screen.dart
@@ -10,19 +10,21 @@ class StartScreen extends StatefulWidget {
 
 class StartScreenState extends State<StartScreen> {
   @override
+  void initState() {
+    final navigatorState = Navigator.of(context);
+    final route = MaterialPageRoute<void>(
+      builder: (context) => const MainPageLayout(),
+    );
+    Future.delayed(const Duration(seconds: 1) * 0.5, () async {
+      await navigatorState.push(route);
+    });
+    super.initState();
+  }
+
+  @override
   Widget build(BuildContext context) {
-    return ColoredBox(
+    return const ColoredBox(
       color: Colors.green,
-      child: TextButton(
-        child: const Text('メイン画面へ'),
-        onPressed: () async {
-          final navigatorState = Navigator.of(context);
-          final route = MaterialPageRoute<void>(
-            builder: (context) => const MainPageLayout(),
-          );
-          await navigatorState.push(route);
-        },
-      ),
     );
   }
 }

--- a/lib/start_screen.dart
+++ b/lib/start_screen.dart
@@ -18,7 +18,7 @@ class _StartScreenState extends State<StartScreen> {
       builder: (context) => const MainPageLayout(),
     );
     // 開始から5秒遅らせて、メイン画面に遷移
-    Future.delayed(const Duration(seconds: 1) * 0.5, () async {
+    Future.delayed(const Duration(milliseconds: 500), () async {
       await navigatorState.push(route);
     });
   }

--- a/lib/start_screen.dart
+++ b/lib/start_screen.dart
@@ -11,6 +11,7 @@ class StartScreen extends StatefulWidget {
 class StartScreenState extends State<StartScreen> {
   @override
   void initState() {
+    super.initState();
     final navigatorState = Navigator.of(context);
     final route = MaterialPageRoute<void>(
       builder: (context) => const MainPageLayout(),
@@ -18,7 +19,6 @@ class StartScreenState extends State<StartScreen> {
     Future.delayed(const Duration(seconds: 1) * 0.5, () async {
       await navigatorState.push(route);
     });
-    super.initState();
   }
 
   @override

--- a/lib/start_screen.dart
+++ b/lib/start_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_training/main_page_layout.dart';
 
+/// 初期画面描画用ウィジェット
 class StartScreen extends StatefulWidget {
   const StartScreen({super.key});
 
@@ -16,6 +17,7 @@ class StartScreenState extends State<StartScreen> {
     final route = MaterialPageRoute<void>(
       builder: (context) => const MainPageLayout(),
     );
+    // 開始から5秒遅らせて、メイン画面に遷移
     Future.delayed(const Duration(seconds: 1) * 0.5, () async {
       await navigatorState.push(route);
     });

--- a/lib/start_screen.dart
+++ b/lib/start_screen.dart
@@ -6,10 +6,10 @@ class StartScreen extends StatefulWidget {
   const StartScreen({super.key});
 
   @override
-  State<StartScreen> createState() => StartScreenState();
+  State<StartScreen> createState() => _StartScreenState();
 }
 
-class StartScreenState extends State<StartScreen> {
+class _StartScreenState extends State<StartScreen> {
   @override
   void initState() {
     super.initState();


### PR DESCRIPTION
## 課題

close #4 

## 対応箇所

<!--
課題のどこに対応したか１つ１つ確認しましょう。
-->

- [x] StatefulWidget を継承した Widget で構築された新しい画面を追加する
- [x] 新しい画面の背景色は Colors.green に設定する
- [x] アプリ起動時に新しい画面に遷移する
- [x] 新しい画面が表示されたら、0.5 秒後に前回まで作っていた画面に遷移する
- [x] 前回まで作っていた画面の Close ボタンをタップすると画面を閉じる

## 動作

https://github.com/tom1236908745/flutter-training-weather-app/assets/60745989/05b55a85-7fed-43d8-9265-9affa8b377bf


