### PR TITLE
Session/5

### DIFF
--- a/lib/components/Dialog/error_message_dialog.dart
+++ b/lib/components/Dialog/error_message_dialog.dart
@@ -1,36 +1,31 @@
 import 'package:flutter/material.dart';
 
-class ErrorMessageDialog extends StatelessWidget {
-  const ErrorMessageDialog({required String errorMessage, super.key})
-      : _errorMessage = errorMessage;
+void handleCloseDialog(BuildContext context) {
+  Navigator.of(context).pop();
+}
 
-  final String _errorMessage;
-
-  void handleCloseDialog(BuildContext context) {
-    Navigator.of(context).pop();
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    return AlertDialog(
-      // TODO: いるか確認
-      // title: const Text('AlertDialog Title'),
-      content: SingleChildScrollView(
-        child: ListBody(
-          children: <Widget>[
-            Text(_errorMessage),
-          ],
+/// エラーメッセージを表示するダイアログ
+Future<void> showErrorDialog(BuildContext context, String errorMessage) async {
+  await showDialog<void>(
+    context: context,
+    builder: (context) {
+      return AlertDialog(
+        content: SingleChildScrollView(
+          child: ListBody(
+            children: <Widget>[
+              Text(errorMessage),
+            ],
+          ),
         ),
-      ),
-      // TODO: 閉じた時にだけ必要(？)
-      actions: <Widget>[
-        TextButton(
-          child: const Text('OK'),
-          onPressed: () {
-            handleCloseDialog(context);
-          },
-        ),
-      ],
-    );
-  }
+        actions: <Widget>[
+          TextButton(
+            child: const Text('OK'),
+            onPressed: () {
+              handleCloseDialog(context);
+            },
+          ),
+        ],
+      );
+    },
+  );
 }

--- a/lib/components/Dialog/error_message_dialog.dart
+++ b/lib/components/Dialog/error_message_dialog.dart
@@ -1,0 +1,36 @@
+import 'package:flutter/material.dart';
+
+class ErrorMessageDialog extends StatelessWidget {
+  const ErrorMessageDialog({required String errorMessage, super.key})
+      : _errorMessage = errorMessage;
+
+  final String _errorMessage;
+
+  void handleCloseDialog(BuildContext context) {
+    Navigator.of(context).pop();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      // TODO: いるか確認
+      // title: const Text('AlertDialog Title'),
+      content: SingleChildScrollView(
+        child: ListBody(
+          children: <Widget>[
+            Text(_errorMessage),
+          ],
+        ),
+      ),
+      // TODO: 閉じた時にだけ必要(？)
+      actions: <Widget>[
+        TextButton(
+          child: const Text('OK'),
+          onPressed: () {
+            handleCloseDialog(context);
+          },
+        ),
+      ],
+    );
+  }
+}

--- a/lib/main_page_layout.dart
+++ b/lib/main_page_layout.dart
@@ -40,31 +40,6 @@ class MainPageLayoutState extends State<MainPageLayout> {
                     const SizedBox(
                       height: 80,
                     ),
-                    // TODO: 後で消す
-                    TextButton(
-                      onPressed: () async => showDialog<String>(
-                        context: context,
-                        builder: (context) => AlertDialog(
-                          // TODO: いるか確認
-                          // title: const Text('AlertDialog Title'),
-                          content: const SingleChildScrollView(
-                            child: ListBody(
-                              children: <Widget>[
-                                Text('error'),
-                              ],
-                            ),
-                          ),
-                          // TODO: 閉じた時にだけ必要(？)
-                          actions: <Widget>[
-                            TextButton(
-                              onPressed: () => Navigator.pop(context, 'OK'),
-                              child: const Text('OK'),
-                            ),
-                          ],
-                        ),
-                      ),
-                      child: const Text('open'),
-                    ),
                     _TextButtons(
                       updateWeatherCondition: _updateWeatherCondition,
                     ),
@@ -172,7 +147,7 @@ class _TextButtons extends StatelessWidget {
         Expanded(
           child: TextButton(
             onPressed: () async {
-              final weatherConditionName = await fetchYumemiWeather();
+              final weatherConditionName = await fetchYumemiWeather(context);
 
               if (weatherConditionName != null) {
                 _updateWeatherCondition(weatherConditionName);

--- a/lib/main_page_layout.dart
+++ b/lib/main_page_layout.dart
@@ -40,6 +40,31 @@ class MainPageLayoutState extends State<MainPageLayout> {
                     const SizedBox(
                       height: 80,
                     ),
+                    // TODO: 後で消す
+                    TextButton(
+                      onPressed: () async => showDialog<String>(
+                        context: context,
+                        builder: (context) => AlertDialog(
+                          // TODO: いるか確認
+                          // title: const Text('AlertDialog Title'),
+                          content: const SingleChildScrollView(
+                            child: ListBody(
+                              children: <Widget>[
+                                Text('error'),
+                              ],
+                            ),
+                          ),
+                          // TODO: 閉じた時にだけ必要(？)
+                          actions: <Widget>[
+                            TextButton(
+                              onPressed: () => Navigator.pop(context, 'OK'),
+                              child: const Text('OK'),
+                            ),
+                          ],
+                        ),
+                      ),
+                      child: const Text('open'),
+                    ),
                     _TextButtons(
                       updateWeatherCondition: _updateWeatherCondition,
                     ),

--- a/lib/repository/fetch_yumemi_weather.dart
+++ b/lib/repository/fetch_yumemi_weather.dart
@@ -1,17 +1,25 @@
 import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_training/components/Dialog/error_message_dialog.dart';
 import 'package:flutter_training/constant/weather_condition.dart';
 import 'package:yumemi_weather/yumemi_weather.dart';
 
-Future<WeatherCondition?> fetchYumemiWeather() async {
+Future<WeatherCondition?> fetchYumemiWeather(BuildContext context) async {
   final yumemiWeather = YumemiWeather();
 
   try {
-    final weatherConditionName = yumemiWeather.fetchSimpleWeather();
+    final weatherConditionName = yumemiWeather.fetchThrowsWeather('tokyo');
+
     return WeatherCondition.from(weatherConditionName);
   } on Exception catch (exception) {
     if (kDebugMode) {
       debugPrint('$exception');
     }
+  } on YumemiWeatherError catch (error) {
+    if (kDebugMode) {
+      debugPrint('$error');
+    }
+    await showErrorDialog(context, 'API取得に失敗しました。\n\nエラー内容: $error');
   }
   return null;
 }

--- a/lib/repository/fetch_yumemi_weather.dart
+++ b/lib/repository/fetch_yumemi_weather.dart
@@ -16,9 +16,6 @@ Future<WeatherCondition?> fetchYumemiWeather(BuildContext context) async {
       debugPrint('$exception');
     }
   } on YumemiWeatherError catch (error) {
-    if (kDebugMode) {
-      debugPrint('$error');
-    }
     await showErrorDialog(context, 'API取得に失敗しました。\n\nエラー内容: $error');
   }
   return null;

--- a/lib/start_screen.dart
+++ b/lib/start_screen.dart
@@ -9,10 +9,19 @@ class StartScreen extends StatefulWidget {
   State<StartScreen> createState() => StartScreenState();
 }
 
-class StartScreenState extends State<StartScreen> {
+mixin AfterDisplayLayout on State<StartScreen> {
+  void afterDisplayLayout();
+}
+
+class StartScreenState extends State<StartScreen> with AfterDisplayLayout {
   @override
   void initState() {
     super.initState();
+    afterDisplayLayout();
+  }
+
+  @override
+  void afterDisplayLayout() {
     final navigatorState = Navigator.of(context);
     final route = MaterialPageRoute<void>(
       builder: (context) => const MainPageLayout(),


### PR DESCRIPTION
## 課題

close #6 

## 対応箇所

<!--
課題のどこに対応したか１つ１つ確認しましょう。
-->

- [x] 使用する API を fetchSimpleWeather() から fetchThrowsWeather() に変更する
- [x] API のエラーを補足して、エラーの内容に応じて AlertDialog でメッセージを表示するメッセージの内容は自由
- [x] AlertDialog の OK ボタンをタップすると、ダイアログを閉じる

## 動作

<!--
画像や動画を添付しましょう。
動作に変更なければ、必要ありません。
-->

https://github.com/tom1236908745/flutter-training-weather-app/assets/60745989/1a863d06-43be-4f4c-a040-fa06f134f831



